### PR TITLE
Fix issue with incorrect array indexing on ir_longitude_control_points

### DIFF
--- a/idl/convert_modis_from_netcdf_to_gds2_netcdf.pro
+++ b/idl/convert_modis_from_netcdf_to_gds2_netcdf.pro
@@ -447,7 +447,7 @@ print, "RANDY_DEBUGGING: cntl_pt_cols & cntl_pt_rows BLOCK BEGIN (netCDF 2 gds2 
 ; data_type_as_int = SIZE(r_controlled_point_cols,/TYPE);
 ; r_data_type = convert_int_type_to_char_type(data_type_as_int);
 
-r_controlled_point_cols = INDGEN(num_lons, START=1)
+r_controlled_point_cols = INDGEN(num_lats, START=1)
 
 ; i_variable_short_name = 'cntl_pt_rows';
 
@@ -476,7 +476,7 @@ r_controlled_point_cols = INDGEN(num_lons, START=1)
 ; r_data_type = convert_int_type_to_char_type(data_type_as_int);
 ; tempvar = SIZE(TEMPORARY(r_controlled_point_rows)); Clear memory
 
-r_controlled_point_rows = INDGEN(num_lats, START=1)
+r_controlled_point_rows = INDGEN(num_lons, START=1)
 
 print, "RANDY_DEBUGGING: cntl_pt_cols & cntl_pt_rows BLOCK END (netCDF 2 gds2 netCDF)\n";
 

--- a/idl/remove_dateline_discontinuity_fast.pro
+++ b/idl/remove_dateline_discontinuity_fast.pro
@@ -20,6 +20,13 @@ FUNCTION remove_dateline_discontinuity_fast,$
 
 ;------------------------------------------------------------------------------------------------
 
+
+debug_module = 'remove_dateline_discontinuity_fast.pro - INFO:';
+
+PRINT, /IMPLIED_PRINT, debug_module + "i_controlled_point_lats: " + STRING(i_controlled_point_lats);
+PRINT, /IMPLIED_PRINT, debug_module + "i_controlled_point_lons: " + STRING(i_controlled_point_lons);
+PRINT, /IMPLIED_PRINT, debug_module + "ir_longitude_control_points: " + STRING(SIZE(ir_longitude_control_points));
+
 ; Load constants.
 
 @modis_data_config.cfg


### PR DESCRIPTION
Swapped the reference to `num_lats` and `num_lons` based on the expected array dimensions.

What tipped me off was the initial definition of num_lons and num_lats: [https://github.com/podaac/generate_processor/blob/1608ce8a646c0793c218a80fc3b5306039ce3d1d/idl/convert_modis_from_netcdf_to_gds2_netcdf.pro#L1[…]129](https://github.com/podaac/generate_processor/blob/1608ce8a646c0793c218a80fc3b5306039ce3d1d/idl/convert_modis_from_netcdf_to_gds2_netcdf.pro#L128-L129)

Combining that with looking at the old versus new OBPG file format I determined that columns was number of pixel control points (now pixels per line) and references lats and rows was scan control points and references lons.

Tested locally and ready to be tested in SIT.